### PR TITLE
Add Python version for host in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,7 @@ env:
   BUILD_TYPE: Release
   LINUX_ARCH: "x86_64"
   MACOS_ARCH: "arm64"
+  HOST_PYTHON: 3.11
 
 jobs:
   prepare:
@@ -145,6 +146,12 @@ jobs:
         run: |
           PV=$(echo "${{ matrix.python-version }}" | tr -d '.')
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.HOST_PYTHON }}
+          cache: pip
 
       - name: Build Linux wheel
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,7 +87,10 @@ jobs:
                   -DCMAKE_OSX_ARCHITECTURES=${{ env.MACOS_ARCH }} \
                   -DCMAKE_PREFIX_PATH="$TORCH_CMAKE_PREFIX_PATH"
             cmake --build build --config ${{ env.BUILD_TYPE }} --parallel
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-wheel -e torch -w {dest_dir} {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            export TORCH_LIB=$(python -c 'import torch; print(torch.__path__[0] + "/lib")')
+            export DYLD_FALLBACK_LIBRARY_PATH="$TORCH_LIB:$DYLD_FALLBACK_LIBRARY_PATH"
+            delocate-wheel -e torch -w {dest_dir} {wheel}
         run: |
           export TORCH_LIB=$(python -c 'import torch; print(torch.__path__[0] + "/lib")')
           export DYLD_FALLBACK_LIBRARY_PATH="$TORCH_LIB:$DYLD_FALLBACK_LIBRARY_PATH"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Configure build env
         run: |
-          PV=${{ matrix.python-version//./}}
+          PV=$(echo "${{ matrix.python-version }}" | tr -d '.')
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=11.1" >> $GITHUB_ENV
           echo "ARCHFLAGS=-arch ${{ env.MACOS_ARCH }}" >> $GITHUB_ENV
@@ -121,7 +121,7 @@ jobs:
 
       - name: Configure build env
         run: |
-          PV=${{ matrix.python-version//./}}
+          PV=$(echo "${{ matrix.python-version }}" | tr -d '.')
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
 
       - name: Setup Python

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-latest
     if: ${{ inputs.build_os == 'Both' || inputs.build_os == 'MacOS' }}
     strategy:
-      fail-fast: true                   # ← moved here
+      fail-fast: true
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.build_os == 'Both' || inputs.build_os == 'Ubuntu' }}
     strategy:
-      fail-fast: true                   # ← and here
+      fail-fast: true
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,14 +3,12 @@ name: Deploy to PyPI
 on:
   workflow_dispatch:
     inputs:
-      version_tag:
-        description: "Release version tag"
-        default: "latest"
       branch:
-        description: "Source branch"
+        description: "Branch"
+        required: true
         default: "main"
       build_os:
-        description: "Select OS to build wheels for"
+        description: "OS"
         required: true
         default: "Both"
         type: choice
@@ -30,54 +28,34 @@ jobs:
     name: Prepare
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.determine_version.outputs.version }}
-      version_no_v: ${{ steps.sanitize.outputs.no_v }}
+      branch: ${{ inputs.branch }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
 
-      - name: Determine version tag
-        id: determine_version
-        run: |
-          if [[ "${{ inputs.version_tag }}" == "latest" ]]; then
-            git fetch --tags
-            echo "version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
-          else
-            echo "version=${{ inputs.version_tag }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout tag (if not latest)
-        if: ${{ inputs.version_tag != 'latest' }}
-        run: |
-          git checkout ${{ steps.determine_version.outputs.version }}
-
-      - name: Strip leading “v” of version tag
-        id: sanitize
-        run: |
-          raw=${{ steps.determine_version.outputs.version }}
-          echo "version_no_v=${raw#v}" >> $GITHUB_OUTPUT
-
   build-macos:
+    name: Build macOS
     needs: prepare
-    name: Build MacOS
     runs-on: macos-latest
     if: ${{ inputs.build_os == 'Both' || inputs.build_os == 'MacOS' }}
     strategy:
-      fail-fast: true
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        fail-fast: true
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.version }}
+          ref: ${{ needs.prepare.outputs.branch }}
+          fetch-depth: 0
 
-      - name: Configure wheel build env
+      - name: Configure build env
         run: |
-          PV=$(echo "${{ matrix.python-version }}" | tr -d '.')
+          PV=${{ matrix.python-version//./}}
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=11.1" >> $GITHUB_ENV
           echo "ARCHFLAGS=-arch ${{ env.MACOS_ARCH }}" >> $GITHUB_ENV
@@ -88,9 +66,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
-      - name: Install deps
-        run: |
-          pip install numpy 'torch>=2.7'
+      - name: Install dependencies
+        run: pip install numpy 'torch>=2.7'
 
       - name: CMake configure
         run: |
@@ -122,29 +99,29 @@ jobs:
       - name: Upload macOS wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.os }}-${{ env.MACOS_ARCH }}-${{ matrix.python-version }}
+          name: wheels-macos-${{ env.MACOS_ARCH }}-${{ matrix.python-version }}
           path: wheelhouse/*.whl
 
   build-linux:
-    needs: prepare
     name: Build Linux
+    needs: prepare
     runs-on: ubuntu-latest
     if: ${{ inputs.build_os == 'Both' || inputs.build_os == 'Ubuntu' }}
     strategy:
-      fail-fast: true
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        fail-fast: true
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.version }}
+          ref: ${{ needs.prepare.outputs.branch }}
           fetch-depth: 0
 
-      - name: Configure wheel build env
+      - name: Configure build env
         run: |
-          PV=$(echo "${{ matrix.python-version }}" | tr -d '.')
+          PV=${{ matrix.python-version//./}}
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
 
       - name: Setup Python
@@ -168,7 +145,7 @@ jobs:
             TORCH_LIB=$(python -c "import torch; print(torch.__path__[0] + '/lib')")
             TORCH_CMAKE_PREFIX_PATH=$(python -c "import torch.utils; print(torch.utils.cmake_prefix_path)")
             export LD_LIBRARY_PATH="$TORCH_LIB:$LD_LIBRARY_PATH"
-            cmake -B build -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+            cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
                   -DPython3_EXECUTABLE=$(which python) \
                   -DCMAKE_PREFIX_PATH="$TORCH_CMAKE_PREFIX_PATH"
             cmake --build build --parallel
@@ -176,30 +153,29 @@ jobs:
           pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
 
-      - name: Upload Ubuntu wheels
+      - name: Upload Linux wheels
         uses: actions/upload-artifact@v4
         with:
           name: wheels-ubuntu-${{ env.LINUX_ARCH }}-${{ matrix.python-version }}
           path: wheelhouse/*.whl
-
   publish-pypi:
     name: Publish to PyPI
-    if: ${{ always() }}
     needs: [build-macos, build-linux]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     permissions:
       id-token: write
       contents: read
 
     steps:
-      - name: Download all wheels
+      - name: Download wheels
         uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
 
-      - name: Merge wheels
+      - name: Merge into dist/
         run: |
-          mkdir dist
+          mkdir -p dist
           find . -name '*.whl' -exec mv {} dist/ \;
 
       - name: Publish to PyPI

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,6 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -53,32 +52,18 @@ jobs:
           ref: ${{ needs.prepare.outputs.branch }}
           fetch-depth: 0
 
+      - name: Setup host Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.HOST_PYTHON }}
+          cache: pip
+
       - name: Configure build env
         run: |
           PV=$(echo "${{ matrix.python-version }}" | tr -d '.')
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=11.1" >> $GITHUB_ENV
           echo "ARCHFLAGS=-arch ${{ env.MACOS_ARCH }}" >> $GITHUB_ENV
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-
-      - name: Install dependencies
-        run: pip install numpy 'torch>=2.7'
-
-      - name: CMake configure
-        run: |
-          TORCH_CMAKE_PREFIX_PATH=$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)')
-          cmake -B build \
-            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-            -DCMAKE_OSX_ARCHITECTURES=${{ env.MACOS_ARCH }} \
-            -DCMAKE_PREFIX_PATH="$TORCH_CMAKE_PREFIX_PATH"
-
-      - name: CMake build
-        run: cmake --build build --parallel
 
       - name: Build macOS wheel
         env:
@@ -89,6 +74,10 @@ jobs:
             delocate-wheel -e torch -w {dest_dir} {wheel}
           CIBW_BEFORE_BUILD: |
             pip install numpy 'torch>=2.7'
+            TORCH_CMAKE_PREFIX_PATH=$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)')
+            cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+                  -DCMAKE_OSX_ARCHITECTURES=${{ env.MACOS_ARCH }} \
+                  -DCMAKE_PREFIX_PATH="$TORCH_CMAKE_PREFIX_PATH"
             cmake --build build --config ${{ env.BUILD_TYPE }} --parallel
         run: |
           export TORCH_LIB=$(python -c 'import torch; print(torch.__path__[0] + "/lib")')
@@ -111,7 +100,6 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -124,7 +112,7 @@ jobs:
           PV=$(echo "${{ matrix.python-version }}" | tr -d '.')
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
 
-      - name: Setup Python
+      - name: Setup host Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.HOST_PYTHON }}
@@ -167,18 +155,15 @@ jobs:
     permissions:
       id-token: write
       contents: read
-
     steps:
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
-
       - name: Merge into dist/
         run: |
           mkdir -p dist
           find . -name '*.whl' -exec mv {} dist/ \;
-
       - name: Publish to PyPI
         if: ${{ needs.build-macos.result == 'success' || needs.build-linux.result == 'success' }}
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,34 +17,44 @@ on:
           - MacOS
           - Ubuntu
 
+concurrency:
+  group: deploy-pypi-${{ github.event.inputs.branch }}
+  cancel-in-progress: true
+
 env:
   BUILD_TYPE: Release
-  LINUX_ARCH: "x86_64"
-  MACOS_ARCH: "arm64"
+  LINUX_ARCH: x86_64
+  MACOS_ARCH: arm64
   HOST_PYTHON: 3.11
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ inputs.branch }}
+      branch: ${{ github.event.inputs.branch }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
 
   build-macos:
     name: Build macOS
     needs: prepare
+    if: ${{ github.event.inputs.build_os == 'Both' || github.event.inputs.build_os == 'MacOS' }}
     runs-on: macos-latest
-    if: ${{ inputs.build_os == 'Both' || inputs.build_os == 'MacOS' }}
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+    env:
+      PY_VERSION: ${{ matrix.python-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,54 +62,52 @@ jobs:
           ref: ${{ needs.prepare.outputs.branch }}
           fetch-depth: 0
 
-      - name: Setup host Python
+      - name: Setup Host Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.HOST_PYTHON }}
           cache: pip
 
-      - name: Configure build env
+      - name: Configure Build Environment
         run: |
-          PV=$(echo "${{ matrix.python-version }}" | tr -d '.')
+          PV=${PY_VERSION//./}
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=11.1" >> $GITHUB_ENV
-          echo "ARCHFLAGS=-arch ${{ env.MACOS_ARCH }}" >> $GITHUB_ENV
+          echo "ARCHFLAGS=-arch $MACOS_ARCH" >> $GITHUB_ENV
 
-      - name: Build macOS wheel
+      - name: Build macOS Wheel
         env:
           CIBW_PLATFORM: macos
-          CIBW_BUILD: cp${{ env.PY_VERSION }}*
+          CIBW_BUILD: cp${{ env.PY_VERSION // '.' }}*
           CIBW_ARCHS: ${{ env.MACOS_ARCH }}
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            delocate-wheel -e torch -w {dest_dir} {wheel}
           CIBW_BEFORE_BUILD: |
             pip install numpy 'torch>=2.7'
             TORCH_CMAKE_PREFIX_PATH=$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)')
-            cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-                  -DCMAKE_OSX_ARCHITECTURES=${{ env.MACOS_ARCH }} \
+            cmake -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+                  -DCMAKE_OSX_ARCHITECTURES=$MACOS_ARCH \
                   -DCMAKE_PREFIX_PATH="$TORCH_CMAKE_PREFIX_PATH"
-            cmake --build build --config ${{ env.BUILD_TYPE }} --parallel
+            cmake --build build --config $BUILD_TYPE --parallel
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-wheel -e torch -w {dest_dir} {wheel}
         run: |
           export TORCH_LIB=$(python -c 'import torch; print(torch.__path__[0] + "/lib")')
           export DYLD_FALLBACK_LIBRARY_PATH="$TORCH_LIB:$DYLD_FALLBACK_LIBRARY_PATH"
           pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
-
-      - name: Upload macOS wheels
+      - name: Upload macOS Wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ env.MACOS_ARCH }}-${{ matrix.python-version }}
+          name: wheels-macos-${{ matrix.python-version }}-${{ env.MACOS_ARCH }}
           path: wheelhouse/*.whl
 
   build-linux:
     name: Build Linux
     needs: prepare
+    if: ${{ github.event.inputs.build_os == 'Both' || github.event.inputs.build_os == 'Ubuntu' }}
     runs-on: ubuntu-latest
-    if: ${{ inputs.build_os == 'Both' || inputs.build_os == 'Ubuntu' }}
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -107,44 +115,42 @@ jobs:
           ref: ${{ needs.prepare.outputs.branch }}
           fetch-depth: 0
 
-      - name: Configure build env
-        run: |
-          PV=$(echo "${{ matrix.python-version }}" | tr -d '.')
-          echo "PY_VERSION=$PV" >> $GITHUB_ENV
-
-      - name: Setup host Python
+      - name: Setup Host Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.HOST_PYTHON }}
           cache: pip
 
-      - name: Build Linux wheel
+      - name: Configure Linux Build Env
+        run: |
+          PV=${{ matrix.python-version//./ }}
+          echo "PY_VERSION=$PV" >> $GITHUB_ENV
+
+      - name: Build Linux Wheel
         env:
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_PLATFORM: linux
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_BUILD: cp${{ env.PY_VERSION }}*
           CIBW_ARCHS: ${{ env.LINUX_ARCH }}
           CIBW_SKIP: "*musllinux*"
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
-            export LD_LIBRARY_PATH=$(python -c "import torch; print(torch.__path__[0] + '/lib')")
-            auditwheel repair --exclude lib*.so -w {dest_dir} {wheel}
           CIBW_BEFORE_BUILD: |
             pip install numpy 'torch>=2.7'
-            TORCH_LIB=$(python -c "import torch; print(torch.__path__[0] + '/lib')")
-            TORCH_CMAKE_PREFIX_PATH=$(python -c "import torch.utils; print(torch.utils.cmake_prefix_path)")
-            export LD_LIBRARY_PATH="$TORCH_LIB:$LD_LIBRARY_PATH"
+            TORCH_CMAKE_PREFIX_PATH=$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)')
+            export LD_LIBRARY_PATH=$(python -c "import torch; print(torch.__path__[0] + '/lib')"):$LD_LIBRARY_PATH
             cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
                   -DPython3_EXECUTABLE=$(which python) \
                   -DCMAKE_PREFIX_PATH="$TORCH_CMAKE_PREFIX_PATH"
             cmake --build build --parallel
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            auditwheel repair --exclude lib*.so -w {dest_dir} {wheel}
         run: |
           pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
 
-      - name: Upload Linux wheels
+      - name: Upload Linux Wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-ubuntu-${{ env.LINUX_ARCH }}-${{ matrix.python-version }}
+          name: wheels-linux-${{ matrix.python-version }}-${{ env.LINUX_ARCH }}
           path: wheelhouse/*.whl
 
   publish-pypi:
@@ -156,14 +162,16 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Download wheels
+      - name: Download Wheels
         uses: actions/download-artifact@v4
         with:
-          pattern: wheels-*
-      - name: Merge into dist/
+          pattern: 'wheels-*'
+
+      - name: Aggregate into dist/
         run: |
           mkdir -p dist
           find . -name '*.whl' -exec mv {} dist/ \;
+
       - name: Publish to PyPI
         if: ${{ needs.build-macos.result == 'success' || needs.build-linux.result == 'success' }}
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,14 +45,14 @@ jobs:
           fetch-depth: 0
 
   build-macos:
-    name: Build macOS
+    name: Build macOS Wheels
     needs: prepare
     if: ${{ github.event.inputs.build_os == 'Both' || github.event.inputs.build_os == 'MacOS' }}
     runs-on: macos-latest
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       MACOSX_DEPLOYMENT_TARGET: 11.1
     steps:
@@ -104,14 +104,14 @@ jobs:
           path: wheelhouse/*.whl
 
   build-linux:
-    name: Build Linux
+    name: Build Linux Wheels
     needs: prepare
     if: ${{ github.event.inputs.build_os == 'Both' || github.event.inputs.build_os == 'Ubuntu' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,9 +42,9 @@ jobs:
     runs-on: macos-latest
     if: ${{ inputs.build_os == 'Both' || inputs.build_os == 'MacOS' }}
     strategy:
+      fail-fast: true                   # ← moved here
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        fail-fast: true
 
     steps:
       - name: Checkout code
@@ -108,9 +108,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.build_os == 'Both' || inputs.build_os == 'Ubuntu' }}
     strategy:
+      fail-fast: true                   # ← and here
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        fail-fast: true
 
     steps:
       - name: Checkout code
@@ -158,6 +158,7 @@ jobs:
         with:
           name: wheels-ubuntu-${{ env.LINUX_ARCH }}-${{ matrix.python-version }}
           path: wheelhouse/*.whl
+
   publish-pypi:
     name: Publish to PyPI
     needs: [build-macos, build-linux]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
     env:
-      PY_VERSION: ${{ matrix.python-version }}
+      MACOSX_DEPLOYMENT_TARGET: 11.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -68,31 +68,31 @@ jobs:
           python-version: ${{ env.HOST_PYTHON }}
           cache: pip
 
-      - name: Configure Build Environment
+      - name: Configure macOS Build Env
         run: |
-          PV=${PY_VERSION//./}
+          $(echo "${{ matrix.python-version }}" | tr -d '.')
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=11.1" >> $GITHUB_ENV
-          echo "ARCHFLAGS=-arch $MACOS_ARCH" >> $GITHUB_ENV
+          echo "ARCHFLAGS=-arch ${{ env.MACOS_ARCH }}" >> $GITHUB_ENV
 
       - name: Build macOS Wheel
         env:
           CIBW_PLATFORM: macos
-          CIBW_BUILD: cp${{ env.PY_VERSION // '.' }}*
+          CIBW_BUILD: cp${{ env.PY_VERSION }}*
           CIBW_ARCHS: ${{ env.MACOS_ARCH }}
           CIBW_BEFORE_BUILD: |
             pip install numpy 'torch>=2.7'
             TORCH_CMAKE_PREFIX_PATH=$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)')
-            cmake -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-                  -DCMAKE_OSX_ARCHITECTURES=$MACOS_ARCH \
+            cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+                  -DCMAKE_OSX_ARCHITECTURES=${{ env.MACOS_ARCH }} \
                   -DCMAKE_PREFIX_PATH="$TORCH_CMAKE_PREFIX_PATH"
-            cmake --build build --config $BUILD_TYPE --parallel
+            cmake --build build --config ${{ env.BUILD_TYPE }} --parallel
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-wheel -e torch -w {dest_dir} {wheel}
         run: |
           export TORCH_LIB=$(python -c 'import torch; print(torch.__path__[0] + "/lib")')
           export DYLD_FALLBACK_LIBRARY_PATH="$TORCH_LIB:$DYLD_FALLBACK_LIBRARY_PATH"
           pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
+
       - name: Upload macOS Wheels
         uses: actions/upload-artifact@v4
         with:
@@ -123,7 +123,7 @@ jobs:
 
       - name: Configure Linux Build Env
         run: |
-          PV=${{ matrix.python-version//./ }}
+          $(echo "${{ matrix.python-version }}" | tr -d '.')
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
 
       - name: Build Linux Wheel

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,8 @@ jobs:
 
       - name: Configure macOS Build Env
         run: |
-          $(echo "${{ matrix.python-version }}" | tr -d '.')
+          PV=${{ matrix.python-version }}
+          PV=${PV//./}
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
           echo "ARCHFLAGS=-arch ${{ env.MACOS_ARCH }}" >> $GITHUB_ENV
 
@@ -123,7 +124,8 @@ jobs:
 
       - name: Configure Linux Build Env
         run: |
-          $(echo "${{ matrix.python-version }}" | tr -d '.')
+          PV=${{ matrix.python-version }}
+          PV=${PV//./}
           echo "PY_VERSION=$PV" >> $GITHUB_ENV
 
       - name: Build Linux Wheel

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@
 
 ## Introduction
 
-DISORT (Discrete Ordinate Radiative Transfer) is a widely-used algorithm that calculates the scattering and absorption of radiation in a medium. The `pydisort` project provides both a high-level Python API and a C++ layer to the well-tested C implementation of DISORT, originally developed in Fortran (Stamnes et al. 1988) and later ported to C as `cdisort` by Timothy E. Dowling, which is a critical component of `libRadTran`. 
+DISORT (Discrete Ordinate Radiative Transfer) is a widely-used algorithm that calculates the scattering and absorption of radiation in a medium. The `pydisort` project provides both a high-level Python API and a C++ layer to the well-tested C implementation of DISORT, originally developed in Fortran (Stamnes et al. 1988) and later ported to C as `cdisort` by Timothy E. Dowling, which is a critical component of `libRadTran`.
 
-To support Python integration, the C code was encapsulated in C++ classes. The C++ wrapper serves two primary purposes: (1) providing a modern C++ interface for the `cdisort` library to facilitate future development involving DISORT, and (2) establishing the foundation for the Python package's bindings. The Python package, which is binded upon the C++ wrapper via `pybind11`, is designed to be user-friendly, making it easy to install and integrate into a diverse range of applications. 
+To support Python integration, the C code was encapsulated in C++ classes. The C++ wrapper serves two primary purposes: (1) providing a modern C++ interface for the `cdisort` library to facilitate future development involving DISORT, and (2) establishing the foundation for the Python package's bindings. The Python package, which is binded upon the C++ wrapper via `pybind11`, is designed to be user-friendly, making it easy to install and integrate into a diverse range of applications.
 
 For efficient memory management and potential GPU acceleration, `pydisort` leverages `PyTorch` tensors, paving the way for future applications in machine learning and large-scale parallel computation.
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@
 
 ## Introduction
 
-DISORT (Discrete Ordinate Radiative Transfer) is a widely-used algorithm that calculates the scattering and absorption of radiation in a medium. The original DISORT algorithm was developed by Stamnes et al. in 1988 and was implemented in `FORTRAN`. Later, Timothy E. Dowling (1999) ported the algorithm to `C`, resulting in the widely-used implementation known as `cdisort`. The `cdisort` library is extensively utilized in atmospheric and remote sensing applications. Notably, it is an integral component of the `libRadtran` radiative transfer model, widely employed in atmospheric and remote sensing studies.
+DISORT (Discrete Ordinate Radiative Transfer) is a widely-used algorithm that calculates the scattering and absorption of radiation in a medium. The `pydisort` project provides both a high-level Python API and a C++ layer to the well-tested C implementation of DISORT, originally developed in Fortran (Stamnes et al. 1988) and later ported to C as `cdisort` by Timothy E. Dowling, which is a critical component of `libRadTran`. 
 
-Building upon the aforementioned work, we have developed a `C++` wrapper for the `cdisort` library and subsequently created a `Python` package. The C++ wrapper serves two primary purposes: (1) providing a modern C++ interface for the `cdisort` library to facilitate future development involving DISORT, and (2) establishing the foundation for the Python package's bindings. The Python package, which is binded upon the C++ wrapper via `pybind11`, is designed to be user-friendly, making it easy to install and integrate into a diverse range of applications.
+To support Python integration, the C code was encapsulated in C++ classes. The C++ wrapper serves two primary purposes: (1) providing a modern C++ interface for the `cdisort` library to facilitate future development involving DISORT, and (2) establishing the foundation for the Python package's bindings. The Python package, which is binded upon the C++ wrapper via `pybind11`, is designed to be user-friendly, making it easy to install and integrate into a diverse range of applications. 
+
+For efficient memory management and potential GPU acceleration, `pydisort` leverages `PyTorch` tensors, paving the way for future applications in machine learning and large-scale parallel computation.
 
 ![](docs/img/rainbow.png)
 


### PR DESCRIPTION
- Add Python version (3.11) for host in CD, as `cibuildwheel3` requires Python 3.11+. See the warning below [here](https://github.com/zoeyzyhu/pydisort/actions/runs/15799380457/job/44535672304#step:8:98).

> Warning: cibuildwheel 3 will require Python 3.11+, please upgrade the Python version used to run cibuildwheel. This does not affect the versions you can target when building wheels. See: https://cibuildwheel.pypa.io/en/stable/#what-does-it-do

- Put the `cmake` build into `cibuildwheel` instead of on the host to avoid mixed `torch` versions between host and the build system.
- Simplified workflow trigger to allow from any branch.
- Fixed small bugs in CD.
- Updated `README.md`.