### PR TITLE
Clean up pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -25,7 +27,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install style checkers
-        run: pip install --user cpplint cppcheck
+        run: |
+          pip install --user cpplint cppcheck
+          pip install --upgrade pre-commit==4.2.0
 
       - name: Cache pre-commit
         uses: actions/cache@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,23 @@
----
+# ──────────────────────────────────────────────────────────────────────────────
+# Move exclude_pattern to top‐level so it applies globally
+exclude: |
+  (?x)^(
+    .*/cdisort\.(c|h)|             # cdisort.c, cdisort.h
+    .*/disort\.hpp|                # disort.hpp
+    .*/COPYING|                    # COPYING
+    .*/DISORT2\.doc|               # DISORT2.doc
+    .*/HOWTO_cdisort|              # HOWTO_cdisort
+    .*/Makefile_cdisort|           # Makefile_cdisort
+    .*/README_cdisort|             # README_cdisort
+    .*/locate\.(c|h)|              # locate.c, locate.h
+    .*/print_test\.c|              # print_test.c
+    .*/test_cdisort.*\.c|          # test_cdisort(_*).c
+    .*/pydisort\.cpp|              # pydisort.cpp
+    python/__init__\.py         # python/__init__.py
+  )$
+# ──────────────────────────────────────────────────────────────────────────────
 repos:
   ## 1. Global check =========================================================
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -9,19 +25,7 @@ repos:
         name: Trim Trailing Whitespace
         entry: trailing-whitespace-fixer
         language: python
-        exclude: &exclude_pattern |
-          (?x)^(
-            .*/cdisort\.(c|h)|             # cdisort.c, cdisort.h
-            .*/disort\.hpp|                # disort.hpp
-            .*/COPYING|                    # COPYING
-            .*/DISORT2\.doc|               # DISORT2.doc
-            .*/HOWTO_cdisort|              # HOWTO_cdisort
-            .*/Makefile_cdisort|           # Makefile_cdisort
-            .*/README_cdisort|             # README_cdisort
-            .*/locate\.(c|h)|              # locate.c, locate.h
-            .*/print_test\.c|              # print_test.c
-            .*/test_cdisort\.c             # test_cdisort.c
-          )$
+        # ← no per-hook exclude needed: the global `exclude:` already covers these files
 
       - id: end-of-file-fixer
       - id: check-merge-conflict
@@ -34,10 +38,6 @@ repos:
     rev: v2.2.4
     hooks:
       - id: codespell
-        name: Check Misspellings
-        language: python
-        description: It looks for a set of common misspellings
-        exclude: *exclude_pattern
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.26.3
@@ -45,7 +45,6 @@ repos:
       - id: check-github-workflows
 
   ## 2. Per language check ===================================================
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -54,35 +53,25 @@ repos:
       - id: requirements-txt-fixer
       - id: check-toml
       - id: check-shebang-scripts-are-executable
-        name: Check that executables have shebangs
-        description: ensures that (non-binary) executables have a shebang.
-        entry: check-executables-have-shebangs
-        types: [text, executable]
-        language: python
 
   ## C/C++ related -----------------------------------------------------------
-
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5
     hooks:
       - id: clang-format
         name: Fix C, C++, Objective-C, Java
         entry: clang-format-hook
-        description: Formats C, C++, Objective-C, and Java code
         types_or: [c, c++, c#, objective-c, java]
         language: python
         args: [--style=Google, -i, --no-diff]
-        exclude: *exclude_pattern
 
       - id: cppcheck
         name: Find warnings/errors in C, C++, and Objective-C
         entry: cppcheck-hook
-        description: Find warnings/errors in C, C++, and Objective-C code
         types_or: [c++, c#, objective-c]
         language: python
         args: [--check-config]
         files: \.(cpp|cc|cxx|h|hpp|hxx)$
-        exclude: *exclude_pattern
 
   ## Python related ----------------------------------------------------------
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -106,14 +95,12 @@ repos:
       - id: pycln
 
   ## 3. Lints ================================================================
-
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5
     hooks:
       - id: cpplint
         name: Find lints in C/C++
         entry: cpplint-hook
-        description: Find warnings/errors in C/CPP code
         types_or: [c, c++, c#, objective-c, cuda]
         language: python
         args:
@@ -121,18 +108,3 @@ repos:
             "--filter=-legal/copyright,-build/include_subdir,-runtime/references,-build/include_order,-runtime/casting,-whitespace/indent_namespace,-build/include_what_you_use,-readability/fn_size,-whitespace/braces,-whitespace/parens,-whitespace/blank_line",
           ]
         files: \.(cpp|cc|cxx|h|hpp|hxx)$
-        exclude: |
-          (?x)^(
-            .*/cdisort\.(c|h)|             # cdisort.c, cdisort.h
-            .*/COPYING|                    # COPYING
-            .*/DISORT2\.doc|               # DISORT2.doc
-            .*/HOWTO_cdisort|              # HOWTO_cdisort
-            .*/Makefile_cdisort|           # Makefile_cdisort
-            .*/README_cdisort|             # README_cdisort
-            .*/locate\.(c|h)|              # locate.c, locate.h
-            .*/print_test\.c|              # print_test.c
-            .*/test_cdisort.*\.c|          # test_cdisort(_*).c
-            .*/pydisort.cpp                # pydisort.cpp
-          )$
-
-exclude: python/__init__.py

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -6,13 +6,16 @@ import atexit
 
 site_packages_dir = sysconfig.get_path("purelib")
 
+
 def cleanup():
     link_path = os.path.join(site_packages_dir, "pydisort", ".dylibs")
     if os.path.exists(link_path) and os.path.islink(link_path):
         os.unlink(link_path)
 
+
 def handle_exit(sig, frame):
     cleanup()
+
 
 def post_install_relink():
     # locations
@@ -34,9 +37,11 @@ def post_install_relink():
     os.makedirs(os.path.dirname(link_path), exist_ok=True)
     os.symlink(torch_path, link_path)
 
+
 # relink libraries
 try:
     import torch
+
     post_install_relink()
 
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import os
 import glob
 import torch

--- a/tests/test_attenuation.py
+++ b/tests/test_attenuation.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """ Test attenuation with pydisort."""
 # pylint: disable = no-name-in-module, invalid-name,
 # import-error, wrong-import-position

--- a/tests/test_disort_01.py
+++ b/tests/test_disort_01.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """ Test isotropic scattering with pydisort."""
 # pylint: disable = no-name-in-module, invalid-name,
 # import-error, wrong-import-position

--- a/tests/test_disort_09.py
+++ b/tests/test_disort_09.py
@@ -1,5 +1,3 @@
-# /usr/bin/env python
-
 """ Test Problem 9: General Emitting/Absorbing/Scattering """
 
 import torch


### PR DESCRIPTION
- Locked down the version numbers for Python (3.11), pre-commit (4.2.0), hooks (see `rev`s) to ensure minimal discrepancies. 
- Fetch the entire history to run pre-commit on. 
- Put excluded files on top to apply to all hooks. 
- Minor lints.