### PR TITLE
Update versions of CI workflow; fix minor release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
           pip install --user cpplint cppcheck pre-commit
 
       - name: Cache pre-commit
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -49,7 +49,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Two main goals:

- Update versions of some actions so that it uses Node 24 instead of 20 - the latter is being deprecated.
- Fix the minor release of the CUDA PR merged before this one (the reason why it failed: for PR originating from a forked repository, GitHub deliberately does not expose repository secrets or variables to the run).